### PR TITLE
Update MCP handshake and preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,18 @@ The server requires the following environment variables to be set:
 - `PAYLOCITY_CLIENT_SECRET` - Your Paylocity API client secret
 - `PAYLOCITY_COMPANY_IDS` - Comma-separated list of company IDs to use
 - `PAYLOCITY_ENVIRONMENT` - API environment to use (`production` or `testing`)
+- `MODEL_COST_PRIORITY` - Optional cost priority for model selection
+- `MODEL_SPEED_PRIORITY` - Optional speed priority for model selection
+- `MODEL_INTELLIGENCE_PRIORITY` - Optional intelligence priority for model selection
+- `MODEL_HINTS` - Optional comma-separated model name hints
 
 These can be set in a `.env` file in the project root directory.
+
+### MCP Handshake
+
+On startup the server responds to the MCP `initialize` request with handshake data
+containing its capabilities, instructions, protocol version and server info. The
+instructions field describes how to use the Paylocity resources and tools.
 
 ## Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ name = "mcppaylocity"
 version = "0.1.0"
 description = "A MCP server to fetch data from paylocity endpoint"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 dependencies = [
-    "mcp>=1.3.0",
+    "mcp>=1.9.3",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0"
 ]

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -23,6 +23,18 @@ startCommand:
         type: string
         default: production
         description: The Paylocity API environment, e.g., production or testing
+      modelCostPriority:
+        type: number
+        description: Optional cost priority for model selection
+      modelSpeedPriority:
+        type: number
+        description: Optional speed priority for model selection
+      modelIntelligencePriority:
+        type: number
+        description: Optional intelligence priority for model selection
+      modelHints:
+        type: string
+        description: Optional comma-separated model name hints
   commandFunction:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
@@ -32,7 +44,11 @@ startCommand:
         PAYLOCITY_CLIENT_ID: config.paylocityClientId,
         PAYLOCITY_CLIENT_SECRET: config.paylocityClientSecret,
         PAYLOCITY_COMPANY_IDS: config.paylocityCompanyIds,
-        PAYLOCITY_ENVIRONMENT: config.paylocityEnvironment
+        PAYLOCITY_ENVIRONMENT: config.paylocityEnvironment,
+        MODEL_COST_PRIORITY: config.modelCostPriority,
+        MODEL_SPEED_PRIORITY: config.modelSpeedPriority,
+        MODEL_INTELLIGENCE_PRIORITY: config.modelIntelligencePriority,
+        MODEL_HINTS: config.modelHints
       }
     })
   exampleConfig:
@@ -40,3 +56,7 @@ startCommand:
     paylocityClientSecret: dummy_secret
     paylocityCompanyIds: 12345,67890
     paylocityEnvironment: testing
+    modelCostPriority: 0.5
+    modelSpeedPriority: 0.2
+    modelIntelligencePriority: 0.8
+    modelHints: gpt-4o

--- a/src/mcppaylocity/paylocity_client.py
+++ b/src/mcppaylocity/paylocity_client.py
@@ -184,5 +184,10 @@ class PaylocityClient:
             response = self._make_request('GET', endpoint)
             return response.json()
         except Exception as e:
-            logger.error("Failed to retrieve employee data for employee %s in company %s: %s", employee_id, company_id, str(e))
-            raise
+            logger.error(
+                "Failed to retrieve employee data for employee %s in company %s: %s",
+                employee_id,
+                company_id,
+                str(e),
+            )
+            raise RuntimeError("Unable to fetch employee sensitive data") from e


### PR DESCRIPTION
## Summary
- upgrade to `mcp>=1.9.3`
- lower Python requirement to `>=3.11`
- expose handshake instructions and server version
- parse optional model preference env vars
- document handshake and model preferences
- extend smithery schema with model preference options
- raise a `RuntimeError` when employee data fetch fails

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68425eca1eec832798c9d38375a10abe